### PR TITLE
Support running samples without composer

### DIFF
--- a/samples/Bootstrap.php
+++ b/samples/Bootstrap.php
@@ -3,11 +3,11 @@
 /**
  * Bootstrap for PhpSpreadsheet classes.
  */
-
-// This sucks, but we have to try to find the composer autoloader
+// Try to find an autoloader.
 
 $paths = [
-    __DIR__ . '/../vendor/autoload.php', // In case PhpSpreadsheet is cloned directly
+    __DIR__ . '/../vendor/autoload.php', // In case PhpSpreadsheet is cloned directly with composer
+    __DIR__ . '/../autoload.php', // When used without composer
     __DIR__ . '/../../../autoload.php', // In case PhpSpreadsheet is a composer dependency.
 ];
 
@@ -19,4 +19,4 @@ foreach ($paths as $path) {
     }
 }
 
-throw new Exception('Composer autoloader could not be found. Install dependencies with `composer install` and try again.');
+throw new Exception('Autoloader could not be found. Install dependencies with `composer install` or include `autoload.php` and try again.');


### PR DESCRIPTION
## Summary
- allow sample bootstrap to use the built-in autoloader when Composer isn't available

## Testing
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_b_68a64835d8cc8325b2ad08f5794bd82f