### PR TITLE
Provide object ID helper for older PHP versions

### DIFF
--- a/src/PhpSpreadsheet/Shared/ObjectIdHelper.php
+++ b/src/PhpSpreadsheet/Shared/ObjectIdHelper.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace PhpOffice\PhpSpreadsheet\Shared;
+
+class ObjectIdHelper
+{
+    public static function id(object $object): int
+    {
+        if (function_exists('spl_object_id')) {
+            return spl_object_id($object);
+        }
+
+        return abs(crc32(spl_object_hash($object)));
+    }
+}
+

--- a/src/PhpSpreadsheet/Style/Style.php
+++ b/src/PhpSpreadsheet/Style/Style.php
@@ -9,6 +9,7 @@ use PhpOffice\PhpSpreadsheet\Exception;
 use PhpOffice\PhpSpreadsheet\Shared\StringHelper;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 use PhpOffice\PhpSpreadsheet\Worksheet\Worksheet;
+use PhpOffice\PhpSpreadsheet\Shared\ObjectIdHelper;
 
 class Style extends Supervisor
 {
@@ -398,7 +399,7 @@ class Style extends Supervisor
                 } else {
                     // Style cache is stored by Style::getHashCode(). But calling this method is
                     // expensive. So we cache the php obj id -> hash.
-                    $objId = spl_object_id($style);
+                    $objId = ObjectIdHelper::id($style);
 
                     // Look for the original HashCode
                     $styleHash = self::$cachedStyles['hashByObjId'][$objId] ?? null;

--- a/src/PhpSpreadsheet/Worksheet/Worksheet.php
+++ b/src/PhpSpreadsheet/Worksheet/Worksheet.php
@@ -25,6 +25,7 @@ use PhpOffice\PhpSpreadsheet\ReferenceHelper;
 use PhpOffice\PhpSpreadsheet\RichText\RichText;
 use PhpOffice\PhpSpreadsheet\Shared;
 use PhpOffice\PhpSpreadsheet\Shared\StringHelper;
+use PhpOffice\PhpSpreadsheet\Shared\ObjectIdHelper;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 use PhpOffice\PhpSpreadsheet\Style\Alignment;
 use PhpOffice\PhpSpreadsheet\Style\Color;
@@ -355,7 +356,7 @@ class Worksheet
     {
         // Set parent and title
         $this->parent = $parent;
-        $this->hash = spl_object_id($this);
+        $this->hash = ObjectIdHelper::id($this);
         $this->setTitle($title, false);
         // setTitle can change $pTitle
         $this->setCodeName($this->getTitle());
@@ -414,7 +415,7 @@ class Worksheet
 
     public function __wakeup(): void
     {
-        $this->hash = spl_object_id($this);
+        $this->hash = ObjectIdHelper::id($this);
     }
 
     /**
@@ -3759,7 +3760,7 @@ class Worksheet
                 }
             }
         }
-        $this->hash = spl_object_id($this);
+        $this->hash = ObjectIdHelper::id($this);
     }
 
     /**


### PR DESCRIPTION
## Summary
- use helper to generate unique IDs when `spl_object_id` isn't available
- update Worksheet and Style to rely on the helper

## Testing
- `php -l src/PhpSpreadsheet/Shared/ObjectIdHelper.php src/PhpSpreadsheet/Worksheet/Worksheet.php src/PhpSpreadsheet/Style/Style.php`
- `phpunit` *(fails: Class "PhpOffice\PhpSpreadsheetTests\Calculation\Functions\Database\SetupTeardownDatabases" not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a658dae9a88325b8ca3d2105868a24